### PR TITLE
fixing an issue where the parts variable was not defined anymore 

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -187,6 +187,7 @@ function vjs_render_media($content, $picture)
 	$poster = embellish_url($picture['current']['src_image']->get_path() );
 	//print $poster;
 
+	$parts = pathinfo($picture['current']['element_url']);
 	// Try to find multiple video source
 	$vjs_extensions = array('ogg', 'ogv', 'mp4', 'm4v', 'webm', 'webmv');
 	$files_ext = array_merge(array(), $vjs_extensions, array_map('strtoupper', $vjs_extensions) );


### PR DESCRIPTION
because of that, 
$filematch = $parts['dirname']."/pwg_representative/".$parts['filename']."-th_*"; (main.inc.php line 226)
was broken (when thumbnails_plugin is activated)