### PR TITLE
Fix Issue with location metadata not containing a Z value.

### DIFF
--- a/include/ffprobe.php
+++ b/include/ffprobe.php
@@ -95,7 +95,7 @@ if (isset($general['tags']['creation_time']))
 if (isset($general['tags']['location']))
 {
 	$gps = (string)$general['tags']['location'];
-	$value = preg_split('/(\+|\-)/', $gps, -1, PREG_SPLIT_DELIM_CAPTURE);
+	$value = preg_split('/(\+|\-|\/)/', $gps, -1, PREG_SPLIT_DELIM_CAPTURE);
 	$exif['latitude'] = $value[1].$value[2];
 	$exif['longitude'] = $value[3].$value[4];
 }

--- a/include/mediainfo.php
+++ b/include/mediainfo.php
@@ -117,7 +117,7 @@ if (isset($general->xyz) or isset($general->comapplequicktimelocationISO6709))	/
     isset($general->xyz) ? $gps = (string)$general->xyz : $gps = (string)$general->comapplequicktimelocationISO6709;
     //$test = "+35.6445-139.7455-029.201/";
     //print_r(preg_split('/(\+|\-)/', $general->xyz, -1, PREG_SPLIT_DELIM_CAPTURE));
-    $value = preg_split('/(\+|\-)/', $gps, -1, PREG_SPLIT_DELIM_CAPTURE);
+    $value = preg_split('/(\+|\-|\/)/', $gps, -1, PREG_SPLIT_DELIM_CAPTURE);
     $exif['latitude'] = $value[1].$value[2];
     $exif['longitude'] = $value[3].$value[4];
 }


### PR DESCRIPTION
Videos from my phone (One Plus 5) do not have Z value in the 'xyz' metadata field: +53.2007+012.8942/
This small fix ignores the trailing '/' in the longitude.